### PR TITLE
🔨 Use laravel route helper function instead hardcode the uri.

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,27 +1,27 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-success">
     <div class="container">
-        <a class="navbar-brand" href="/">Warnetku</a>
+        <a class="navbar-brand" href="{{route('home')}}">Warnetku</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav">
                 <li class="nav-item">
-                    <a class="nav-link active" href="/computer">Computer</a>
+                    <a class="nav-link active" href="{{ route('computer.index') }}">Computer</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link active" href="/price">Price</a>
+                    <a class="nav-link active" href="{{ route('price.index') }}">Price</a>
                 </li>
                 @can('is-owner')
                 <li class="nav-item">
-                    <a class="nav-link active" href="/operator">Operator</a>
+                    <a class="nav-link active" href="{{ route('operator.index') }}">Operator</a>
                 </li>
                 @endcan
                 <li class="nav-item">
-                    <a class="nav-link active" href="/transaction">Transaction</a>
+                    <a class="nav-link active" href="{{ route('transaction.index') }}">Transaction</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link active" href="/report">Report</a>
+                    <a class="nav-link active" href="{{ route('report') }}">Report</a>
                 </li>
             </ul>
             <ul class="navbar-nav ms-auto">
@@ -34,11 +34,11 @@
                             <h6 class="dropdown-header">Login as <span class="fw-bold">{{ Auth::user()->fullname }}</span></h6>
                         </li>
                         <li class="dropdown-item">
-                            <a href="/me" class="link-dark">My Profile</a>
+                            <a href="{{ route('me.show') }}" class="link-dark">My Profile</a>
                         </li>
                         <li class="dropdown-divider"></li>
                         <li class="dropdown-item">
-                            <a href="/logout" class="link-danger">Logout</a>
+                            <a href="{{ route('logout') }}" class="link-danger">Logout</a>
                         </li>
                     </ul>
                 </li>

--- a/resources/views/computer/create.blade.php
+++ b/resources/views/computer/create.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/computer" method="post">
+        <form action="{{ route('computer.store') }}" method="post">
             @csrf
             <div class="mb-3">
                 <label for="name" class="form-label">Name</label>

--- a/resources/views/computer/edit.blade.php
+++ b/resources/views/computer/edit.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/computer/{{ $computer->id }}" method="post">
+        <form action="{{ route('computer.update', $computer->id) }}" method="post">
             @csrf
             @method('put')
             <div class="mb-3">

--- a/resources/views/computer/index.blade.php
+++ b/resources/views/computer/index.blade.php
@@ -8,7 +8,7 @@
 <div class="row g-3">
     @foreach($computers as $computer)
     <div class="col-lg-3 col-md-4 col-sm-6 col-12">
-        <a @can('is-owner') href="/computer/{{ $computer->id }}" @endcan class="p-4 bg-light border d-block text-dark text-decoration-none">
+        <a @can('is-owner') href="{{ route('computer.show', $computer->id) }}" @endcan class="p-4 bg-light border d-block text-dark text-decoration-none">
             <h3>{{ $computer->name }}</h3>
             <p class="">{{ $computer->type->name }}</p>
             <div class="text-muted"><i class="bi bi-dot"></i>
@@ -25,7 +25,7 @@
     @endforeach
     @can('is-owner')
     <div class="col-lg-3 col-md-4 col-sm-6 col-12">
-        <a href="/computer/create" class="p-4 bg-light border border-success d-block text-success h-100">
+        <a href="{{ route('computer.create') }}" class="p-4 bg-light border border-success d-block text-success h-100">
             <h3>Add Computer +</h3>
         </a>
     </div>

--- a/resources/views/computer/show.blade.php
+++ b/resources/views/computer/show.blade.php
@@ -30,7 +30,7 @@
             </tbody>
         </table>
         <div class="pt-2">
-            <a href="/computer/{{ $computer->id }}/edit" class="btn btn-primary">Edit</a>
+            <a href="{{ route('computer.edit', $computer->id) }}" class="btn btn-primary">Edit</a>
             <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modalDelete">Delete</button>
 
             <div class="modal fade" id="modalDelete" tabindex="-1">
@@ -44,7 +44,7 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                            <form action="/computer/{{ $computer->id }}" method="post">
+                            <form action="{{ route('computer.destroy', $computer->id) }}" method="post">
                                 @csrf
                                 @method('delete')
                                 <button type="submit" class="btn btn-danger">Delete</button>

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -3,7 +3,7 @@
 
 <div class="row px-3 d-flex justify-content-center align-items-center vh-100">
     <div class="col p-4 bg-light border" style="max-width: 400px;">
-        <form action="/login" method="post">
+        <form action="{{ route('auth') }}" method="post">
             @csrf
             <div class="mb-4">
                 <h2>Warnetku - Login</h2>

--- a/resources/views/operator/create.blade.php
+++ b/resources/views/operator/create.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/operator" method="post">
+        <form action="{{ route('operator.store') }}" method="post">
             @csrf
             <div class="mb-3">
                 <label for="fullname" class="form-label">Full Name</label>

--- a/resources/views/operator/edit.blade.php
+++ b/resources/views/operator/edit.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/operator/{{ $operator->id }}" method="post">
+        <form action="{{ route('operator.update', $operator->id) }}" method="post">
             @csrf
             @method('put')
             <div class="mb-3">

--- a/resources/views/operator/index.blade.php
+++ b/resources/views/operator/index.blade.php
@@ -3,7 +3,7 @@
 
 <div class="mb-3 d-sm-flex d-block align-items-center">
     <h1 class="">Operators</h1>
-    <a href="/operator/create" class="btn btn-outline-success ms-auto btn-lg">Add Operator</a>
+    <a href="{{ route('operator.create') }}" class="btn btn-outline-success ms-auto btn-lg">Add Operator</a>
 </div>
 
 @include('components.notif')
@@ -28,7 +28,7 @@
                     <td>{{ $operator->username }}</td>
                     <td>{{ $operator->role->name }}</td>
                     <td class="col-1">
-                        <a href="/operator/{{ $operator->username }}" class="btn btn-sm btn-primary">
+                        <a href="{{ route('operator.show', $operator->username) }}" class="btn btn-sm btn-primary">
                             Detail
                         </a>
                     </td>

--- a/resources/views/operator/show.blade.php
+++ b/resources/views/operator/show.blade.php
@@ -24,7 +24,7 @@
             </tbody>
         </table>
         <div class="pt-2">
-            <a href="/operator/{{ $operator->username }}/edit" class="btn btn-primary">Edit</a>
+            <a href="{{ route('operator.update', $operator->username) }}" class="btn btn-primary">Edit</a>
             @if($operator->role->name != 'Owner')
             <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modalDelete">Delete</button>
             <div class="modal fade" id="modalDelete" tabindex="-1">
@@ -38,7 +38,7 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                            <form action="/operator/{{ $operator->id }}" method="post">
+                            <form action="{{ route('operator.destroy', $operator->id) }}" method="post">
                                 @csrf
                                 @method('delete')
                                 <button type="submit" class="btn btn-danger">Delete</button>

--- a/resources/views/price/create.blade.php
+++ b/resources/views/price/create.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/price" method="post">
+        <form action="{{ route('price.store') }}" method="post">
             @csrf
             <div class="mb-3">
                 <label for="name" class="form-label">Name</label>

--- a/resources/views/price/edit.blade.php
+++ b/resources/views/price/edit.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/price/{{ $rental->id }}" method="post">
+        <form action="{{ route('price.update', $rental->id) }}" method="post">
             @csrf
             @method('put')
             <div class="mb-3">

--- a/resources/views/price/index.blade.php
+++ b/resources/views/price/index.blade.php
@@ -4,7 +4,7 @@
 <div class="mb-3 d-sm-flex d-block align-items-center">
     <h1 class="">Rental Prices</h1>
     @can('is-owner')
-    <a href="/price/create" class="btn btn-outline-success ms-auto btn-lg">Add Rental Price</a>
+    <a href="{{ route('price.create') }}" class="btn btn-outline-success ms-auto btn-lg">Add Rental Price</a>
     @endcan
 </div>
 
@@ -13,7 +13,7 @@
 <div class="row g-3">
     @foreach($gaming_prices as $rental)
     <div class="col-lg-3 col-md-4 col-sm-6 col-12">
-        <a @can('is-owner') href="/price/{{ $rental->id }}" @endcan class="p-4 bg-light border d-block text-dark text-decoration-none">
+        <a @can('is-owner') href="{{ route('price.show'. $rental->id) }}" @endcan class="p-4 bg-light border d-block text-dark text-decoration-none">
             <h4>{{ $rental->name }}</h4>
             <h5 class="fw-normal">Rp. {{ $rental->price }}</h5>
             <div class="text-muted d-flex justify-content-between pt-3">
@@ -31,7 +31,7 @@
 <div class="row g-3 mt-1">
     @foreach($office_prices as $rental)
     <div class="col-lg-3 col-md-4 col-sm-6 col-12">
-        <a @can('is-owner') href="/price/{{ $rental->id }}" @endcan class="p-4 bg-light border d-block text-dark text-decoration-none">
+        <a @can('is-owner') href="{{ route('price.show'. $rental->id) }}" @endcan class="p-4 bg-light border d-block text-dark text-decoration-none">
             <h4>{{ $rental->name }}</h4>
             <h5 class="fw-normal">Rp. {{ $rental->price }}</h5>
             <div class="text-muted d-flex justify-content-between pt-3">

--- a/resources/views/price/show.blade.php
+++ b/resources/views/price/show.blade.php
@@ -28,7 +28,7 @@
             </tbody>
         </table>
         <div class="pt-2">
-            <a href="/price/{{ $rental->id }}/edit" class="btn btn-primary">Edit</a>
+            <a href="{{ route('price.edit', $rental->id) }}" class="btn btn-primary">Edit</a>
             <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modalDelete">Delete</button>
 
             <div class="modal fade" id="modalDelete" tabindex="-1">
@@ -42,7 +42,7 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                            <form action="/price/{{ $rental->id }}" method="post">
+                            <form action="{{ route('price.destroy', $rental->id) }}" method="post">
                                 @csrf
                                 @method('delete')
                                 <button type="submit" class="btn btn-danger">Delete</button>

--- a/resources/views/profile/edit-password.blade.php
+++ b/resources/views/profile/edit-password.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/me/change-password" method="post">
+        <form action="{{ route('me.update-password') }}" method="post">
             @csrf
             @method('put')
 

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/me" method="post">
+        <form action="{{ route('me.show') }}" method="post">
             @csrf
             @method('put')
             <div class="mb-3">

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -24,8 +24,8 @@
             </tbody>
         </table>
         <div class="pt-2">
-            <a href="/me/edit" class="btn btn-primary">Edit</a>
-            <a href="/me/change-password" class="btn btn-primary">Change Password</a>
+            <a href="{{ route('me.edit') }}" class="btn btn-primary">Edit</a>
+            <a href="{{ route('me.edit-password') }}" class="btn btn-primary">Change Password</a>
         </div>
     </div>
 </div>

--- a/resources/views/transaction/create.blade.php
+++ b/resources/views/transaction/create.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/transaction" method="post">
+        <form action="{{ route('transaction.store') }}" method="post">
             @csrf
             <div class="mb-3">
                 <label for="customer" class="form-label">Customer Name</label>

--- a/resources/views/transaction/edit.blade.php
+++ b/resources/views/transaction/edit.blade.php
@@ -5,7 +5,7 @@
 
 <div class="row">
     <div class="col-lg-4 col-md-8">
-        <form action="/transaction/{{ $transaction->id }}" method="post">
+        <form action="{{ route('transaction.update', $transaction->id) }}" method="post">
             @csrf
             @method('put')
             <div class="mb-3">

--- a/resources/views/transaction/index.blade.php
+++ b/resources/views/transaction/index.blade.php
@@ -4,8 +4,8 @@
 <div class="mb-3 d-sm-flex d-block align-items-center justify-content-between">
     <h1>Transactions</h1>
     <div>
-        <a href="/transaction/all" class="btn btn-lg btn-outline-primary">Transaction History</a>
-        <a href="/transaction/create" class="btn btn-lg btn-outline-success">Add Transaction</a>
+        <a href="{{ route('transaction.all') }}" class="btn btn-lg btn-outline-primary">Transaction History</a>
+        <a href="{{ route('transaction.create') }}" class="btn btn-lg btn-outline-success">Add Transaction</a>
     </div>
 </div>
 
@@ -33,7 +33,7 @@
                     <td>{{ $transaction->duration  }}</td>
                     <td>{{ $transaction['remaining_time'] }}</td>
                     <td class="col-1">
-                        <a href="/transaction/{{ $transaction->id }}" class="btn btn-sm btn-primary">Detail</a>
+                        <a href="{{ route('transaction.show', $transaction->id) }}" class="btn btn-sm btn-primary">Detail</a>
                     </td>
                 </tr>
                 @endforeach

--- a/resources/views/transaction/index_all.blade.php
+++ b/resources/views/transaction/index_all.blade.php
@@ -33,7 +33,7 @@
                     <td>{{ $transaction->duration  }}</td>
                     <td>Rp. {{ $transaction['bill'] }}</td>
                     <td class="col-1">
-                        <a href="/transaction/{{ $transaction->id }}" class="btn btn-sm btn-primary">Detail</a>
+                        <a href="{{ route('transaction.show', $transaction->id) }}" class="btn btn-sm btn-primary">Detail</a>
                     </td>
                 </tr>
                 @endforeach

--- a/resources/views/transaction/show.blade.php
+++ b/resources/views/transaction/show.blade.php
@@ -31,7 +31,7 @@
                                     <div class="modal-header">
                                         <h5 class="modal-title" id="exampleModalLabel">Add duration</h5>
                                     </div>
-                                    <form action="/transaction/{{ $transaction->id }}/extend" method="post">
+                                    <form action="{{ route('transaction.extends', $transaction->id) }}" method="post">
                                         @csrf
                                         @method('patch')
                                         <div class="modal-body">
@@ -77,7 +77,7 @@
         </table>
         @can('manage-transaction', $transaction)
         <div class="pt-2">
-            <a href="/transaction/{{ $transaction->id }}/edit" class="btn btn-primary">Edit</a>
+            <a href="{{ route('transaction.edit', $transaction->id ) }}" class="btn btn-primary">Edit</a>
             <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modalDelete">Delete</button>
 
             <div class="modal fade" id="modalDelete" tabindex="-1">
@@ -91,7 +91,7 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                            <form action="/transaction/{{ $transaction->id }}" method="post">
+                            <form action="{{ route('transaction.destroy', $transaction->id) }}" method="post">
                                 @csrf
                                 @method('delete')
                                 <button type="submit" class="btn btn-danger">Delete</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ use App\Http\Controllers\ReportController;
 Route::middleware('auth')->group(function () {
     Route::get('/', function () {
         return view('home');
-    });
+    })->name('home');
 
     Route::resource('computer', ComputerController::class)->scoped([
         'computer' => 'id'
@@ -43,31 +43,31 @@ Route::middleware('auth')->group(function () {
         'operator' => 'username'
     ]);
 
-    Route::prefix('transaction')->group(function () {
-        Route::get('/all', [TransactionController::class, 'indexAll']);
-        Route::patch('/{transaction:id}/extend', [TransactionController::class, 'extend']);
+    Route::prefix('transaction')->name('transaction.')->group(function () {
+        Route::get('/all', [TransactionController::class, 'indexAll'])->name('all');
+        Route::patch('/{transaction:id}/extend', [TransactionController::class, 'extend'])->name('extends');
         Route::resource('/', TransactionController::class)->parameters([
             '' => 'transaction'
         ])->scoped([
             'transaction' => 'id'
-        ])->names('transaction');
+        ]);
     });
 
 
-    Route::prefix('me')->group(function () {
-        Route::get('/', [ProfileController::class, 'index']);
-        Route::get('/edit', [ProfileController::class, 'edit']);
-        Route::get('/change-password', [ProfileController::class, 'editPassword']);
-        Route::put('/', [ProfileController::class, 'update']);
-        Route::put('/change-password', [ProfileController::class, 'updatePassword']);
+    Route::prefix('me')->name('me.')->group(function () {
+        Route::get('/', [ProfileController::class, 'index'])->name('show');
+        Route::get('/edit', [ProfileController::class, 'edit'])->name('edit');
+        Route::get('/change-password', [ProfileController::class, 'editPassword'])->name('edit-password');
+        Route::put('/', [ProfileController::class, 'update'])->name('update');
+        Route::put('/change-password', [ProfileController::class, 'updatePassword'])->name('update-password');
     });
 
-    Route::get('/report', [ReportController::class, 'index']);
+    Route::get('/report', [ReportController::class, 'index'])->name('report');
 
-    Route::get('/logout', [AuthController::class, 'logout']);
+    Route::get('/logout', [AuthController::class, 'logout'])->name('logout');
 });
 
 Route::middleware('guest')->group(function () {
     Route::get('/login', [AuthController::class, 'index'])->name('login');
-    Route::post('/login', [AuthController::class, 'login']);
+    Route::post('/login', [AuthController::class, 'login'])->name('auth');
 });


### PR DESCRIPTION
### Purpose of change.

Since some of the `route` are defined using `Route::resource` these also generate not only typical `http` request but also generate name for the individual `route`, so we can remove all hardcode `uri` in the link and form submit action to use Laravel helper method route to generate the `uri` we already define in route.

## Describe the solution.

Replace all hardcode link and form submit action to use function `route`, and added `name prefix` for unamed `route`.

### Describe alternatives you've considered.

Leave as is, or maybe you want to implement in your own naming convention, you are feel free to do so.

### Testing.

Working properly without any error in local server.

### Reference

[Laravel route name prefix docs.](https://laravel.com/docs/9.x/routing#route-group-name-prefixes)
[Laravel route resource action docs.](https://laravel.com/docs/9.x/controllers#actions-handled-by-resource-controller)
[Laravel route helper function docs.](https://laravel.com/docs/9.x/helpers#method-route)