### PR TITLE
🔨  change `GET` to `POST` on logout

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -38,7 +38,11 @@
                         </li>
                         <li class="dropdown-divider"></li>
                         <li class="dropdown-item">
-                            <a href="{{ route('logout') }}" class="link-danger">Logout</a>
+                            <form action="{{ route('logout') }}" method="post">
+                                @csrf
+                                <input style="border: 0; background-color: transparent; text-decoration: underline"
+                                    class="link-danger" type="submit" value="Logout">
+                            </form>
                         </li>
                     </ul>
                 </li>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -40,8 +40,9 @@
                         <li class="dropdown-item">
                             <form action="{{ route('logout') }}" method="post">
                                 @csrf
-                                <input style="border: 0; background-color: transparent; text-decoration: underline"
-                                    class="link-danger" type="submit" value="Logout">
+                                <button type="submit" class="border-0 bg-transparent text-decoration-underline link-danger">
+                                    Logout
+                                </button>
                             </form>
                         </li>
                     </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,7 +64,7 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/report', [ReportController::class, 'index'])->name('report');
 
-    Route::get('/logout', [AuthController::class, 'logout'])->name('logout');
+    Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 });
 
 Route::middleware('guest')->group(function () {


### PR DESCRIPTION
### Purpose of change.

It's probably good idea to put the logout button to `POST` HTTP method because if someone put some link and someone press then redirect to someone page to indirect logout is no good, who want to get logged out mysteriously.

## Describe the solution.

Change logout route from get to post, and change logout link into form.

### Describe alternatives you've considered.

Well we can keep on using get but that's probably bad idea.

### Testing.

Working properly on local development server.

### Reference

[Stackoverflow question.](https://stackoverflow.com/questions/3521290/logout-get-or-post)